### PR TITLE
new option -- expire_batch

### DIFF
--- a/amti/actions/__init__.py
+++ b/amti/actions/__init__.py
@@ -8,3 +8,4 @@ from amti.actions.review import review_batch
 from amti.actions.save import save_batch
 from amti.actions.delete import delete_batch
 from amti.actions.extract import extract_xml
+from amti.actions.expire import expire_batch

--- a/amti/actions/expire.py
+++ b/amti/actions/expire.py
@@ -1,0 +1,68 @@
+"""Functions for expiring all (unanswered) HITs"""
+
+import collections
+import json
+import logging
+import os
+import datetime
+
+from amti import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def expire_batch(
+        client,
+        batch_dir):
+    """Expire all the (unanswered) HITs in the batch.
+
+    Parameters
+    ----------
+    client : MTurk.Client
+        a boto3 client for MTurk.
+    batch_dir : str
+        the path to the directory for the batch.
+
+    Returns
+    -------
+    Dict[str, int]
+        A dictionary mapping strings to integers. The dictionary will
+        have the following form::
+
+            {
+                'batch_id': batch_id,
+            }
+
+        where ``batch_id`` is the UUID for the batch.
+    """
+    # construct important paths
+    batch_dir_name, batch_dir_subpaths = settings.BATCH_DIR_STRUCTURE
+    batchid_file_name, _ = batch_dir_subpaths['batchid']
+    incomplete_file_name = settings.INCOMPLETE_FILE_NAME
+
+    batchid_file_path = os.path.join(
+        batch_dir, batchid_file_name)
+    incomplete_file_path = os.path.join(
+        batch_dir, settings.INCOMPLETE_FILE_NAME)
+
+    with open(batchid_file_path) as batchid_file:
+        batch_id = batchid_file.read().strip()
+
+    if not os.path.isfile(incomplete_file_path):
+        raise ValueError(
+            f'No {incomplete_file_name} file was found in {batch_dir}.'
+            f' Please make sure the batch name.')
+    with open(incomplete_file_path) as incomplete_file:
+        hit_ids = json.load(incomplete_file)['hit_ids']
+
+    logger.info(f'Making batch {batch_id} expired.')
+
+    for hit_id in hit_ids:
+        hit = client.update_expiration_for_hit(HITId=hit_id, ExpireAt=datetime.datetime.now())
+
+    logger.info(f'The batch {batch_id} is expired now.')
+
+    return {
+        'batch_id': batch_id,
+    }

--- a/amti/actions/expire.py
+++ b/amti/actions/expire.py
@@ -51,16 +51,17 @@ def expire_batch(
     if not os.path.isfile(incomplete_file_path):
         raise ValueError(
             f'No {incomplete_file_name} file was found in {batch_dir}.'
-            f' Please make sure the batch name.')
+            f' Please make sure that the directory is a batch that has'
+            f' open HITs to be expired.')
     with open(incomplete_file_path) as incomplete_file:
         hit_ids = json.load(incomplete_file)['hit_ids']
 
-    logger.info(f'Making batch {batch_id} expired.')
+    logger.info(f'Expiring HITs in batch {batch_id}.')
 
     for hit_id in hit_ids:
         hit = client.update_expiration_for_hit(HITId=hit_id, ExpireAt=datetime.datetime.now())
 
-    logger.info(f'The batch {batch_id} is expired now.')
+    logger.info(f'All HITs in batch {batch_id} are now expired.')
 
     return {
         'batch_id': batch_id,

--- a/amti/actions/expire.py
+++ b/amti/actions/expire.py
@@ -59,10 +59,12 @@ def expire_batch(
     logger.info(f'Expiring HITs in batch {batch_id}.')
 
     for hit_id in hit_ids:
-        hit = client.update_expiration_for_hit(HITId=hit_id, ExpireAt=datetime.datetime.now())
+        hit = client.update_expiration_for_hit(
+            HITId=hit_id,
+            ExpireAt=datetime.datetime.now())
 
     logger.info(f'All HITs in batch {batch_id} are now expired.')
 
     return {
-        'batch_id': batch_id,
+        'batch_id': batch_id
     }

--- a/amti/actions/expire.py
+++ b/amti/actions/expire.py
@@ -1,6 +1,5 @@
 """Functions for expiring all (unanswered) HITs"""
 
-import collections
 import json
 import logging
 import os

--- a/amti/clis/__init__.py
+++ b/amti/clis/__init__.py
@@ -8,3 +8,4 @@ from amti.clis.review import review_batch
 from amti.clis.save import save_batch
 from amti.clis.delete import delete_batch
 from amti.clis.extract import extract_xml
+from amti.clis.expire import expire_batch

--- a/amti/clis/create.py
+++ b/amti/clis/create.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import boto3
 import click
 
 from amti import actions

--- a/amti/clis/delete.py
+++ b/amti/clis/delete.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import boto3
 import click
 
 from amti import actions

--- a/amti/clis/expire.py
+++ b/amti/clis/expire.py
@@ -38,6 +38,5 @@ def expire_batch(batch_dir, live):
         batch_dir=batch_dir)
 
     batch_id = batch_expire['batch_id']
-    print('Finished expiring batch.')
 
     logger.info('Finished expiring batch.')

--- a/amti/clis/expire.py
+++ b/amti/clis/expire.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import boto3
 import click
 
 from amti import actions

--- a/amti/clis/expire.py
+++ b/amti/clis/expire.py
@@ -1,0 +1,44 @@
+"""Command line interfaces for viewing the statuses of HITs"""
+
+import logging
+
+import boto3
+import click
+
+from amti import actions
+from amti import settings
+from amti.utils import mturk as mturk_utils
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings={
+        'help_option_names': ['--help', '-h']
+    })
+@click.argument(
+    'batch_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option(
+    '--live', '-l',
+    is_flag=True,
+    help='View the status of HITs from the live MTurk site.')
+def expire_batch(batch_dir, live):
+    """Expire all the HITs defined in BATCH_DIR.
+
+    Given a directory (BATCH_DIR) that represents a batch of HITs in MTurk, 
+    expire all the unanswered HITs.
+    """
+    env = 'live' if live else 'sandbox'
+
+    client = mturk_utils.get_mturk_client(env)
+
+    batch_expire = actions.expire_batch(
+        client=client,
+        batch_dir=batch_dir)
+
+    batch_id = batch_expire['batch_id']
+    print('Finished expiring batch.')
+
+    logger.info('Finished expiring batch.')

--- a/amti/clis/expire.py
+++ b/amti/clis/expire.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def expire_batch(batch_dir, live):
     """Expire all the HITs defined in BATCH_DIR.
 
-    Given a directory (BATCH_DIR) that represents a batch of HITs in MTurk, 
+    Given a directory (BATCH_DIR) that represents a batch of HITs in MTurk,
     expire all the unanswered HITs.
     """
     env = 'live' if live else 'sandbox'

--- a/amti/clis/expire.py
+++ b/amti/clis/expire.py
@@ -1,4 +1,4 @@
-"""Command line interfaces for viewing the statuses of HITs"""
+"""Command line interfaces for expiring the HITs"""
 
 import logging
 
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     '--live', '-l',
     is_flag=True,
-    help='View the status of HITs from the live MTurk site.')
+    help='Expire the HITs from the live MTurk site.')
 def expire_batch(batch_dir, live):
     """Expire all the HITs defined in BATCH_DIR.
 

--- a/amti/clis/save.py
+++ b/amti/clis/save.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import boto3
 import click
 
 from amti import actions

--- a/amti/clis/status.py
+++ b/amti/clis/status.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import boto3
 import click
 
 from amti import actions

--- a/readme.md
+++ b/readme.md
@@ -82,11 +82,15 @@ site.
 
          amti status_batch batch-*
 
-  5. Since your batch is now ready for review, review it with:
+  5. (optional) If you want to cancel all the HITs in the batch:
+
+         amti expire_batch batch-*
+
+  6. Since your batch is now ready for review, review it with:
 
          amti review_batch batch-*
 
-  6. Once you've approved all of your HITs, you can save the results
+  7. Once you've approved all of your HITs, you can save the results
      from the batch:
 
          amti save_batch batch-*
@@ -95,7 +99,7 @@ site.
      new `results` subdirectory with the information on your HITs and
      assignments.
 
-  7. Since you've saved your batch, dispose of it from the MTurk site
+  8. Since you've saved your batch, dispose of it from the MTurk site
      using:
 
          amti delete_batch batch-*
@@ -104,7 +108,7 @@ site.
      up when you examine your open HITs; however, it leaves your batch
      directory intact and unchanged.
 
-  8. Lastly, you can extract XML from all the assignments you've saved
+  9. Lastly, you can extract XML from all the assignments you've saved
      into your batch directory using the following command:
 
          amti extract_xml batch-* .
@@ -222,6 +226,7 @@ To use `amti` as a CLI for Mechanical Turk, [install](#installation)
     Commands:
       create_batch  Create a batch of HITs using DEFINITION_DIR...
       delete_batch  Delete the batch of HITs defined in...
+      expire_batch  Cancel (expire) a batch of open HITs defined in...
       extract_xml   Extract XML data from assignments in...
       review_batch  Review the batch of HITs defined in...
       save_batch    Save results from the batch of HITs defined...

--- a/scripts/amti
+++ b/scripts/amti
@@ -41,7 +41,9 @@ subcommands = [
     # extract xml
     clis.extract_xml,
     # create a qualification type
-    clis.create_qualificationtype
+    clis.create_qualificationtype,
+    # expire
+    clis.expire_batch,
 ]
 
 for subcommand in subcommands:


### PR DESCRIPTION
I added an option that allows to cancel all the open HITs by expiring them.
At this moment, I use it mainly for testing UI etc. on a sandbox environment.