### PR TITLE
Add extract tabular

### DIFF
--- a/amti/actions/__init__.py
+++ b/amti/actions/__init__.py
@@ -1,5 +1,6 @@
 """Actions for managing HITs and their results"""
 
+from amti.actions import extraction
 from amti.actions.create import (
     create_batch,
     create_qualificationtype)
@@ -7,5 +8,4 @@ from amti.actions.status import status_batch
 from amti.actions.review import review_batch
 from amti.actions.save import save_batch
 from amti.actions.delete import delete_batch
-from amti.actions.extract import extract_xml
 from amti.actions.expire import expire_batch

--- a/amti/actions/extraction/__init__.py
+++ b/amti/actions/extraction/__init__.py
@@ -1,0 +1,3 @@
+"""Actions for extracting data from batches"""
+
+from amti.actions.extraction.xml import xml

--- a/amti/actions/extraction/__init__.py
+++ b/amti/actions/extraction/__init__.py
@@ -1,3 +1,4 @@
 """Actions for extracting data from batches"""
 
+from amti.actions.extraction.tabular import tabular
 from amti.actions.extraction.xml import xml

--- a/amti/actions/extraction/tabular.py
+++ b/amti/actions/extraction/tabular.py
@@ -1,0 +1,182 @@
+"""A function for extracting batch data into a tabular format."""
+
+import csv
+import html
+import json
+import logging
+import os
+from xml.dom import minidom
+
+import click
+
+from amti import settings
+from amti import utils
+
+
+logger = logging.getLogger(__name__)
+
+
+TABULAR_SUPPORTED_FILE_FORMATS = [
+    'csv',
+    'json',
+    'jsonl'
+]
+"""File formats supported by the ``tabular`` function."""
+# Make sure to update the doc strings for
+# ``amti.actions.extraction.tabular.tabular`` and
+# ``amti.clis.extraction.tabular.tabular`` if you edit this constant.
+
+
+def tabular(
+        batch_dir,
+        output_path,
+        file_format):
+    """Extract data in ``batch_dir`` to ``output_path`` as a table.
+
+    Extract batch data into a tabular format; however, some metadata may
+    not be copied over. Each assignment will become it's own row in the
+    table with a separate column for each form field, as well as much of
+    the assignment's metadata. The table will be written to
+    ``output_path`` in the format specified by ``file_format``.
+
+    Parameters
+    ----------
+    batch_dir : str
+        the path to the batch's directory.
+    output_path : str
+        the path where the output file should be saved.
+    file_format : str
+        the file format to use when writing the data. Must be one of the
+        supported file formats: csv (CSV), json (JSON), jsonl (JSON
+        Lines).
+
+    Returns
+    -------
+    None.
+    """
+    if file_format not in TABULAR_SUPPORTED_FILE_FORMATS:
+        raise ValueError(
+            'file_format must be one of {formats}.'.format(
+                formats=', '.join(TABULAR_SUPPORTED_FILE_FORMATS)))
+
+    # construct important paths
+    _, batch_dir_subpaths = settings.BATCH_DIR_STRUCTURE
+    batchid_file_name, _ = batch_dir_subpaths['batchid']
+    results_dir_name, results_dir_subpaths = batch_dir_subpaths['results']
+    _, hit_dir_subpaths = results_dir_subpaths['hit_dir']
+    hit_file_name, _ = hit_dir_subpaths['hit']
+    assignments_file_name, _ = hit_dir_subpaths['assignments']
+
+    batchid_file_path = os.path.join(
+        batch_dir, batchid_file_name)
+    results_dir = os.path.join(batch_dir, results_dir_name)
+
+    with open(batchid_file_path) as batchid_file:
+        batch_id = batchid_file.read().strip()
+
+    logger.info(
+        f'Beginning to extract batch {batch_id} to tabular format.')
+
+    rows = []
+    for dir_path, dir_names, file_names in os.walk(results_dir):
+        hit = None
+        assignments = None
+        for file_name in file_names:
+            if file_name == hit_file_name:
+                hit_path = os.path.join(dir_path, file_name)
+                with open(hit_path, 'r') as hit_file:
+                    hit = json.load(hit_file)
+            elif file_name == assignments_file_name:
+                assignments_path = os.path.join(
+                    dir_path, assignments_file_name)
+                with open(assignments_path, 'r') as assignments_file:
+                    assignments = [
+                        json.loads(ln.strip())
+                        for ln in assignments_file
+                    ]
+            else:
+                logger.warning(
+                    f'Unexected file ({file_name}) located in'
+                    f' {dir_path}')
+
+        if hit is None or assignments is None:
+            # if both ``hit`` and ``assignments`` are ``None``, then
+            # this directory is simply not one we're interested in;
+            # however, if exactly one is ``None`` then there's likely
+            # been an error.
+            if hit is None and assignments is not None:
+                logger.warning(
+                    f'Found assignments but no HIT in {dir_path}.')
+            elif hit is not None and assignments is None:
+                logger.warning(
+                    f'Found HIT but no assignments in {dir_path}.')
+            continue
+
+        for assignment in assignments:
+            row = {}
+
+            # add relevant metadata from the HIT
+            row['HITId'] = hit['HIT']['HITId']
+            row['AssignmentDurationInSeconds'] =\
+                hit['HIT']['AssignmentDurationInSeconds']
+            row['AutoApprovalDelayInSeconds'] =\
+                hit['HIT']['AutoApprovalDelayInSeconds']
+            row['Expiration'] = hit['HIT']['Expiration']
+            row['CreationTime'] = hit['HIT']['CreationTime']
+
+            # add relevant metadata from the assignment
+            row['AssignmentId'] = assignment['AssignmentId']
+            row['WorkerId'] = assignment['WorkerId']
+            row['AssignmentStatus'] = assignment['AssignmentStatus']
+            row['AutoApprovalTime'] = assignment['AutoApprovalTime']
+            row['AcceptTime'] = assignment['AcceptTime']
+            row['SubmitTime'] = assignment['SubmitTime']
+            row['ApprovalTime'] = assignment['ApprovalTime']
+
+            # parse the response and add it to the row
+            xml = minidom.parseString(assignment['Answer'])
+            for answer_tag in xml.getElementsByTagName('Answer'):
+                [question_identifier_tag] =\
+                    answer_tag.getElementsByTagName(
+                        'QuestionIdentifier')
+                question_identifier = utils.xml.get_node_text(
+                    question_identifier_tag)
+
+                if question_identifier == 'doNotRedirect':
+                    # some workers on Mechanical Turk modify their
+                    # browser requests to send a 'doNotRedirect'
+                    # field when posting results.
+                    logger.warning(
+                        f'Found a "doNotRedirect" field in'
+                        f' {dir_path}. Dropping the field.')
+                    continue
+
+                [free_text_tag] = answer_tag.getElementsByTagName(
+                    'FreeText')
+                free_text = html.unescape(
+                    utils.xml.get_node_text(free_text_tag))
+
+                row[question_identifier] = free_text
+
+            rows.append(row)
+
+    with click.open_file(output_path, 'w') as output_file:
+        if file_format == 'csv':
+            csv_writer = csv.DictWriter(
+                output_file,
+                fieldnames=rows[0].keys())
+            csv_writer.writeheader()
+            csv_writer.writerows(rows)
+        elif file_format == 'json':
+            json.dump(rows, output_file)
+        elif file_format == 'jsonl':
+            output_file.write('\n'.join([
+                json.dumps(row)
+                for row in rows
+            ]))
+        else:
+            raise NotImplementedError(
+                f'Support for {file_format} has not been implemented.')
+
+    logger.info(
+        f'Finished extracting batch {batch_id} to tabular format.')

--- a/amti/actions/extraction/xml.py
+++ b/amti/actions/extraction/xml.py
@@ -1,4 +1,4 @@
-"""Function for extracting data from a batch"""
+"""A function for extracting data from a batch as XML"""
 
 import json
 import logging
@@ -13,7 +13,7 @@ from amti import settings
 logger = logging.getLogger(__name__)
 
 
-def extract_xml(
+def xml(
         batch_dir,
         output_dir):
     """Extract the XML from assignments in a batch.

--- a/amti/actions/extraction/xml.py
+++ b/amti/actions/extraction/xml.py
@@ -52,6 +52,9 @@ def xml(
     with open(batchid_file_path) as batchid_file:
         batch_id = batchid_file.read().strip()
 
+    logger.info(
+        f'Beginning to extract batch {batch_id} to XML.')
+
     xml_dir_name = settings.XML_DIR_NAME_TEMPLATE.format(
         batch_id=batch_id)
     xml_dir_path = os.path.join(output_dir, xml_dir_name)
@@ -80,4 +83,5 @@ def xml(
 
         shutil.copytree(working_dir, xml_dir_path)
 
-    logger.info(f'Extracting xml from batch {batch_id}.')
+    logger.info(
+        f'Finished extracting batch {batch_id} to XML.')

--- a/amti/clis/__init__.py
+++ b/amti/clis/__init__.py
@@ -1,5 +1,6 @@
 """CLIs for managing HITs and their results"""
 
+from amti.clis import extraction
 from amti.clis.create import (
     create_batch,
     create_qualificationtype)
@@ -7,5 +8,5 @@ from amti.clis.status import status_batch
 from amti.clis.review import review_batch
 from amti.clis.save import save_batch
 from amti.clis.delete import delete_batch
-from amti.clis.extract import extract_xml
+from amti.clis.extract import extract
 from amti.clis.expire import expire_batch

--- a/amti/clis/extract.py
+++ b/amti/clis/extract.py
@@ -4,29 +4,33 @@ import logging
 
 import click
 
-from amti import actions
+from amti import clis
 
 
 logger = logging.getLogger(__name__)
 
 
-@click.command(
+@click.group(
     context_settings={
         'help_option_names': ['--help', '-h']
     })
-@click.argument(
-    'batch_dir',
-    type=click.Path(exists=True, file_okay=False, dir_okay=True))
-@click.argument(
-    'output_dir',
-    type=click.Path(exists=True, file_okay=False, dir_okay=True))
-def extract_xml(batch_dir, output_dir):
-    """Extract XML data from assignments in BATCH_DIR to OUTPUT_DIR.
+def extract():
+    """Extract data from a batch to various formats.
 
-    Given a directory (BATCH_DIR) that represents a batch of HITs that
-    have been reviewed and saved, extract the XML data from the
-    assignments to OUTPUT_DIR.
+    See the subcommands for extracting batch data into a specific
+    format.
     """
-    actions.extract_xml(batch_dir=batch_dir, output_dir=output_dir)
+    pass
 
-    logger.info('Finished extracting batch.')
+
+subcommands = [
+    # xml
+    clis.extraction.xml
+]
+
+for subcommand in subcommands:
+    extract.add_command(subcommand)
+
+
+if __name__ == '__main__':
+    extract()

--- a/amti/clis/extract.py
+++ b/amti/clis/extract.py
@@ -24,6 +24,8 @@ def extract():
 
 
 subcommands = [
+    # tabular
+    clis.extraction.tabular,
     # xml
     clis.extraction.xml
 ]

--- a/amti/clis/extraction/__init__.py
+++ b/amti/clis/extraction/__init__.py
@@ -1,0 +1,3 @@
+"""Commands for extracting batch data into various formats"""
+
+from amti.clis.extraction.xml import xml

--- a/amti/clis/extraction/__init__.py
+++ b/amti/clis/extraction/__init__.py
@@ -1,3 +1,4 @@
 """Commands for extracting batch data into various formats"""
 
+from amti.clis.extraction.tabular import tabular
 from amti.clis.extraction.xml import xml

--- a/amti/clis/extraction/tabular.py
+++ b/amti/clis/extraction/tabular.py
@@ -1,0 +1,43 @@
+"""Command line interface for extracting tabular data from a batch"""
+
+import logging
+
+import click
+
+from amti import actions
+from amti.actions.extraction.tabular import (
+    TABULAR_SUPPORTED_FILE_FORMATS)
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings={
+        'help_option_names': ['--help', '-h']
+    })
+@click.argument(
+    'batch_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.argument(
+    'output_path',
+    type=click.Path(exists=False, file_okay=True, dir_okay=False))
+@click.option(
+    '--format', '-f', 'file_format',
+    type=click.Choice(TABULAR_SUPPORTED_FILE_FORMATS),
+    default='jsonl',
+    help='The desired output file format.')
+def tabular(batch_dir, output_path, file_format):
+    """Extract data from BATCH_DIR to OUTPUT_PATH in a tabular format.
+
+    Given a directory (BATCH_DIR) that represents a batch of HITs that
+    have been reviewed and saved, extract the data to OUTPUT_PATH in a
+    tabular format. Every row of the table is an assignment, where each
+    form field has a column and also there are additional columns for
+    assignment metadata. By default, the table will be saved as JSON
+    Lines, but other formats may be specified with the --format option.
+    """
+    actions.extraction.tabular(
+        batch_dir=batch_dir,
+        output_path=output_path,
+        file_format=file_format)

--- a/amti/clis/extraction/xml.py
+++ b/amti/clis/extraction/xml.py
@@ -28,5 +28,3 @@ def xml(batch_dir, output_dir):
     assignments to OUTPUT_DIR.
     """
     actions.extraction.xml(batch_dir=batch_dir, output_dir=output_dir)
-
-    logger.info('Finished extracting batch.')

--- a/amti/clis/extraction/xml.py
+++ b/amti/clis/extraction/xml.py
@@ -1,0 +1,32 @@
+"""Command line interface for extracting XML from a batch"""
+
+import logging
+
+import click
+
+from amti import actions
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings={
+        'help_option_names': ['--help', '-h']
+    })
+@click.argument(
+    'batch_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.argument(
+    'output_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True))
+def xml(batch_dir, output_dir):
+    """Extract XML data from assignments in BATCH_DIR to OUTPUT_DIR.
+
+    Given a directory (BATCH_DIR) that represents a batch of HITs that
+    have been reviewed and saved, extract the XML data from the
+    assignments to OUTPUT_DIR.
+    """
+    actions.extraction.xml(batch_dir=batch_dir, output_dir=output_dir)
+
+    logger.info('Finished extracting batch.')

--- a/amti/utils/__init__.py
+++ b/amti/utils/__init__.py
@@ -1,1 +1,7 @@
 """Utilities for ``amti``"""
+
+from amti.utils import log
+from amti.utils import mturk
+from amti.utils import serialization
+from amti.utils import validation
+from amti.utils import xml

--- a/amti/utils/xml.py
+++ b/amti/utils/xml.py
@@ -1,0 +1,36 @@
+"""Utilities for processing XML."""
+
+from xml.dom import minidom
+
+
+def get_node_text(node):
+    """Return the text from a node that has only text as content.
+
+    Calling this function on a node with multiple children or a non-text
+    node child raises a ``ValueError``.
+
+    Parameters
+    ----------
+    node : xml.dom.minidom.Node
+        The node to extract text from.
+
+    Returns
+    -------
+    str
+        The text from node.
+    """
+    # handle the empty node case
+    if len(node.childNodes) == 0:
+        return ''
+
+    # check error conditions
+    if len(node.childNodes) > 1:
+        raise ValueError(
+            f'node ({node}) has multiple child nodes.')
+
+    if not isinstance(node.childNodes[0], minidom.Text):
+        raise ValueError(
+            f"node's ({node}) child node is not a Text node.")
+
+    # return the child node's text
+    return node.childNodes[0].wholeText

--- a/readme.md
+++ b/readme.md
@@ -134,9 +134,9 @@ site.
      For real workflows, it would be a good idea to use the batch id in
      the name of the output file.
 
- Now you've run a small HIT and have the results in a reproducible
- format. It's easy to tar up and upload the batch directory to the cloud
- where you can store information from many such HITs.
+Now you've run a small HIT and have the results in a reproducible
+format. It's easy to tar up and upload the batch directory to the cloud
+where you can store information from many such HITs.
 
 [examples-directory]: ./examples/
 [worker-sandbox]: https://workersandbox.mturk.com/
@@ -231,7 +231,7 @@ HITs with `amti delete_batch`. Again, use `-h` for details.
 To use `amti` as a CLI for Mechanical Turk, [install](#installation)
 `amti` and then call it by typing `amti` at the command line:
 
-    $ amti -h
+    $ amti --help
     Usage: amti [OPTIONS] COMMAND [ARGS]...
 
       Alexandria Mechanical Turk Interface: a CLI for MTurk.

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,8 @@ site.
            -h, --help  Show this message and exit.
 
          Commands:
-           xml  Extract XML data from assignments in...
+           tabular  Extract data from BATCH_DIR to OUTPUT_PATH in...
+           xml      Extract XML data from assignments in...
 
      The `xml` subcommand will extract all the XML data returned by
      Mechanical Turk into a directory of XML files:

--- a/readme.md
+++ b/readme.md
@@ -126,14 +126,13 @@ site.
            tabular  Extract data from BATCH_DIR to OUTPUT_PATH in...
            xml      Extract XML data from assignments in...
 
-     The `xml` subcommand will extract all the XML data returned by
-     Mechanical Turk into a directory of XML files:
+     The `tabular` command will extract the batch's data into an easy to
+     work with tabular format:
 
-         amti extract xml batch-* .
+         amti extract tabular batch-* batch-data.jsonl
 
-     The `.` signifies that the extracted XML should be saved in the
-     current directory. You can view the XML with the standard command
-     line tools: `ls` and `emacs`.
+     For real workflows, it would be a good idea to use the batch id in
+     the name of the output file.
 
  Now you've run a small HIT and have the results in a reproducible
  format. It's easy to tar up and upload the batch directory to the cloud

--- a/readme.md
+++ b/readme.md
@@ -108,10 +108,27 @@ site.
      up when you examine your open HITs; however, it leaves your batch
      directory intact and unchanged.
 
-  9. Lastly, you can extract XML from all the assignments you've saved
-     into your batch directory using the following command:
+  9. Lastly, you can extract data from all the assignments you've saved
+     into your batch directory using any of the `extract` commands. To
+     view the available extraction formats, pass the `--help` option:
 
-         amti extract_xml batch-* .
+         $ amti extract --help
+         Usage: amti extract [OPTIONS] COMMAND [ARGS]...
+
+           Extract data from a batch to various formats.
+
+           See the subcommands for extracting batch data into a specific format.
+
+         Options:
+           -h, --help  Show this message and exit.
+
+         Commands:
+           xml  Extract XML data from assignments in...
+
+     The `xml` subcommand will extract all the XML data returned by
+     Mechanical Turk into a directory of XML files:
+
+         amti extract xml batch-* .
 
      The `.` signifies that the extracted XML should be saved in the
      current directory. You can view the XML with the standard command
@@ -224,13 +241,14 @@ To use `amti` as a CLI for Mechanical Turk, [install](#installation)
       -h, --help     Show this message and exit.
 
     Commands:
-      create_batch  Create a batch of HITs using DEFINITION_DIR...
-      delete_batch  Delete the batch of HITs defined in...
-      expire_batch  Cancel (expire) a batch of open HITs defined in...
-      extract_xml   Extract XML data from assignments in...
-      review_batch  Review the batch of HITs defined in...
-      save_batch    Save results from the batch of HITs defined...
-      status_batch  View the status of the batch of HITs defined...
+      create_batch              Create a batch of HITs using DEFINITION_DIR...
+      create_qualificationtype  Create a Qualification Type using...
+      delete_batch              Delete the batch of HITs defined in...
+      expire_batch              Expire all the HITs defined in BATCH_DIR.
+      extract                   Extract data from a batch to various formats.
+      review_batch              Review the batch of HITs defined in...
+      save_batch                Save results from the batch of HITs defined...
+      status_batch              View the status of the batch of HITs defined...
 
 The CLI is self-documenting and hierarchical, so you should be able to
 find anything you might need by starting from the top and using the `-h`

--- a/scripts/amti
+++ b/scripts/amti
@@ -38,12 +38,12 @@ subcommands = [
     clis.save_batch,
     # delete
     clis.delete_batch,
-    # extract xml
-    clis.extract_xml,
+    # extract (command group)
+    clis.extract,
     # create a qualification type
     clis.create_qualificationtype,
     # expire
-    clis.expire_batch,
+    clis.expire_batch
 ]
 
 for subcommand in subcommands:


### PR DESCRIPTION
This pull request adds a command to extract all the batch data in a tabular format.

The new command is:

```
$ amti extract tabular --help
Usage: amti extract tabular [OPTIONS] BATCH_DIR OUTPUT_PATH

  Extract data from BATCH_DIR to OUTPUT_PATH in a tabular format.

  Given a directory (BATCH_DIR) that represents a batch of HITs that have
  been reviewed and saved, extract the data to OUTPUT_PATH in a tabular
  format. Every row of the table is an assignment, where each form field has
  a column and also there are additional columns for assignment metadata. By
  default, the table will be saved as JSON Lines, but other formats may be
  specified with the --format option.

Options:
  -f, --format [csv|json|jsonl]  The desired output file format.
  -h, --help                     Show this message and exit.
```

The command should be helpful in pulling out all the batch data into a form that's easier to work with than the directory tree of XML files we used previously.

Additionally, this pull request changes the command line interface by taking the old `extract_xml` command and grouping it with the new `tabular` command as `xml` under the `extract` command group.