### PR TITLE
Enable use of AWS_PROFILE

### DIFF
--- a/amti/utils/mturk.py
+++ b/amti/utils/mturk.py
@@ -33,6 +33,7 @@ def get_mturk_client(env):
 
     profile = os.getenv('AWS_PROFILE')
     if profile is None:
+        logger.debug('Creating mturk session with default environment/profile values.')
         session = boto3.session.Session()
     else:
         logger.debug(f'Creating mturk session with profile_name {profile}')

--- a/amti/utils/mturk.py
+++ b/amti/utils/mturk.py
@@ -1,6 +1,7 @@
 """Utilities for interacting with MTurk."""
 
 import logging
+import os
 
 import boto3
 
@@ -30,10 +31,17 @@ def get_mturk_client(env):
     region_name = settings.ENVS[env]['region_name']
     endpoint_url = settings.ENVS[env]['endpoint_url']
 
+    profile = os.getenv('AWS_PROFILE')
+    if profile is None:
+        session = boto3.session.Session()
+    else:
+        logger.debug(f'Creating mturk session with profile_name {profile}')
+        session = boto3.session.Session(profile_name=profile)
+
     logger.debug(
         f'Creating mturk client in region {region_name} with endpoint'
         f' {endpoint_url}.')
-    client = boto3.client(
+    client = session.client(
         service_name='mturk',
         region_name=region_name,
         endpoint_url=endpoint_url)

--- a/readme.md
+++ b/readme.md
@@ -283,17 +283,16 @@ install the dependencies:
     echo 'amti' > .python-version
     pip install -r requirements.txt
 
-Then, make sure that you have the proper AWS environment variables set in
-your `.envrc` file for this repo. In particular, you should have values
+Then, make sure that you have the proper [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) set in your `.envrc` file for this repo. In particular, you should have values
 for either:
 ```
-    AWS_ACCESS_KEY_ID
-    AWS_SECRET_KEY
-    AWS_SECRET_ACCESS_KEY
+AWS_ACCESS_KEY_ID
+AWS_SECRET_KEY
+AWS_SECRET_ACCESS_KEY
 ```
 or
 ```
-    AWS_PROFILE
+AWS_PROFILE
 ```
 
 That correspond to your Mechanical Turk account.

--- a/readme.md
+++ b/readme.md
@@ -283,13 +283,18 @@ install the dependencies:
     echo 'amti' > .python-version
     pip install -r requirements.txt
 
-Then, make sure that you have the proper environment variables set in
+Then, make sure that you have the proper AWS environment variables set in
 your `.envrc` file for this repo. In particular, you should have values
-for:
-
+for either:
+```
     AWS_ACCESS_KEY_ID
     AWS_SECRET_KEY
     AWS_SECRET_ACCESS_KEY
+```
+or
+```
+    AWS_PROFILE
+```
 
 That correspond to your Mechanical Turk account.
 


### PR DESCRIPTION
Enable users to use a named AWS profile in their `.envrc` instead of explicitly adding their AWS access keys.