### PR TITLE
return the batch dir name after creating a bunch of HITS

### DIFF
--- a/amti/actions/create.py
+++ b/amti/actions/create.py
@@ -284,6 +284,8 @@ def create_batch(
         batch_dir=batch_dir)
 
     logger.info('HIT Creation Complete.')
+    
+    return batch_dir
 
 
 def create_qualificationtype(

--- a/amti/actions/create.py
+++ b/amti/actions/create.py
@@ -268,7 +268,8 @@ def create_batch(
 
     Returns
     -------
-    None
+    str
+        the path to the batch directory.
     """
     logger.info('Writing batch.')
 
@@ -284,7 +285,7 @@ def create_batch(
         batch_dir=batch_dir)
 
     logger.info('HIT Creation Complete.')
-    
+
     return batch_dir
 
 

--- a/amti/clis/create.py
+++ b/amti/clis/create.py
@@ -64,14 +64,14 @@ def create_batch(definition_dir, data_path, save_dir, live):
 
     client = utils.mturk.get_mturk_client(env)
 
-    actions.create.create_batch(
+    batch_dir = actions.create.create_batch(
         client=client,
         definition_dir=definition_dir,
         data_path=data_path,
         save_dir=save_dir)
 
     logger.info(
-        f'Finished.'
+        f'Finished creating batch directory: {batch_dir}.'
         f'\n'
         f'\n    Preview HITs: {worker_url}'
         f'\n')


### PR DESCRIPTION
Why it's useful to return the `batch_dir`? 
Since in any follow-up commands (like status check, saving, reviewing, etc) you'd need this address. 