### PR TITLE
Fix failure to catch error when running amti outside a git repo

### DIFF
--- a/amti/utils/log.py
+++ b/amti/utils/log.py
@@ -87,7 +87,7 @@ def get_current_commit():
 
     if not git_installed:
         current_commit = None
-    elif b'fatal: Not a git repository' in process.stderr:
+    elif b'fatal: not a git repository' in process.stderr.lower():
         current_commit = None
     else:
         process.check_returncode()
@@ -120,7 +120,7 @@ def is_repo_clean():
 
     if not git_installed:
         clean_repo = None
-    elif b'fatal: Not a git repository' in process.stderr:
+    elif b'fatal: not a git repository' in process.stderr.lower():
         clean_repo = None
     else:
         process.check_returncode()


### PR DESCRIPTION
This pull request fixes https://github.com/allenai/amti/issues/8. Namely, error messages
are not properly caught when running amti outside of a git repository.