### PR TITLE
Fix bug from writing a null commit SHA when outside a git repo

### DIFF
--- a/amti/actions/create.py
+++ b/amti/actions/create.py
@@ -75,7 +75,7 @@ def initialize_batch_directory(
             readme_file.write(settings.BATCH_README)
 
         # write the COMMIT file
-        current_commit = utils.log.get_current_commit()
+        current_commit = utils.log.get_current_commit() or '<none>'
         commit_path = os.path.join(working_dir, commit_file_name)
         with open(commit_path, 'w') as commit_file:
             commit_file.write(current_commit)


### PR DESCRIPTION
This pull request addresses https://github.com/allenai/amti/issues/9.

When creating a batch outside of a git repository, the commit SHA
is unavailable and thus None. This pull request replaces the None value
with a short string, "<none>", suitable for writing to the COMMIT
file in the batch directory.