### PR TITLE
 adding an option to list the workers associated with a certain qual.

### DIFF
--- a/amti/clis/__init__.py
+++ b/amti/clis/__init__.py
@@ -2,6 +2,7 @@
 
 from amti.clis import (
     associate,
+    associated,
     block,
     create,
     delete,

--- a/amti/clis/associated.py
+++ b/amti/clis/associated.py
@@ -1,0 +1,50 @@
+"""Command line interface for listing associated Workers with quals"""
+
+import logging
+
+import click
+
+from amti import actions
+from amti import settings
+from amti import utils
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings={
+        'help_option_names': ['--help', '-h']
+    })
+@click.option(
+    '--qual', '-q', 
+    help='QualificationId (or name, if --name flag passed).')
+@click.option(
+    '--status', '-s',
+    help='The status of the Qualifications to return. Can be `Granted` or `Revoked`.')
+@click.option(
+    '--live', '-l',
+    is_flag=True,
+    help='View the status of HITs from the live MTurk site.')
+def associated(qual, status, live):
+    """List all the Workers that have been associated with a given Qualification type.
+
+    NOTE: Only works with quals that both exist and are owned by the user.
+    """
+    env = 'live' if live else 'sandbox'
+
+    client = utils.mturk.get_mturk_client(env)
+    logger.info(f'Listing all the workers associated with {qual} (status: {status}) . . . ')
+
+    response = client.list_workers_with_qualification_type(
+        QualificationTypeId=qual,
+        Status=status
+    )
+    if response['NumResults'] == 0:
+        logger.info("No one is associated! ")
+    else:
+        logger.info("List of workers: ")
+        for w in response['Qualifications']:
+            logger.info(f" -> WorkerId: {w['WorkerId']} - granted-time: {w['GrantTime']}")
+
+    logger.info('Finished listing the workers.')

--- a/scripts/amti
+++ b/scripts/amti
@@ -54,6 +54,8 @@ subcommands = [
     clis.associate.associate_qual,
     # disassociate qual
     clis.disassociate.disassociate_qual,
+    # list workers associated with a qual
+    clis.associated.associated,
     # preview
     clis.preview.preview_batch
 ]


### PR DESCRIPTION
Example usage: 

```
$ amti  associated --qual  QualID --status Granted  --live 
2021-09-28 10:09:15,210:INFO:amti.clis.associated:Listing all the workers associated with QualID (status: Granted) . . . 
2021-09-28 10:09:15,618:INFO:amti.clis.associated:No one is associated! 
2021-09-28 10:09:15,618:INFO:amti.clis.associated:Finished listing the workers.
```
